### PR TITLE
Enable `Full` linkage for wasm project.

### DIFF
--- a/LinkerWorkaround/LinkerWorkaround.xml
+++ b/LinkerWorkaround/LinkerWorkaround.xml
@@ -1,5 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <linker>
-  <assembly fullname="Samples" preserve="all"/>
-  <assembly fullname="glTFLoader" preserve="all"/>
+  <!--
+  Preserve some System types to work around newtonsoft.json reflection calls
+  for glTFLoader.Interface.LoadModel.
+  -->
+  <assembly fullname="System">
+        <type fullname="System.ComponentModel.AttributeCollection"/>
+        <type fullname="System.Collections.Specialized.OrderedDictionary"/>
+        <type fullname="System.ComponentModel.INotifyPropertyChanged"/>
+  </assembly>
+
 </linker>

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <NoWarn>NU1701;NU1604</NoWarn>
-    <MonoWasmLinkMode>None</MonoWasmLinkMode>
+    <MonoWasmLinkMode>Full</MonoWasmLinkMode>
+    <MonoWasmLinkSkip>glTFLoader</MonoWasmLinkSkip>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
-  Unfortunately still need the LinkerWorkaround.xml to work around some System types that are needed by NewtonSoft.Json when loading the GLTF sample.  The deserializer uses reflection so the linker does not know that these are indeed needed.